### PR TITLE
fix namespaces issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ spec:
 EOF
 ```
 Once the cluster `ServiceCatalogControllerManager` is found to exist and have a `managementState` of `Managed` the operator will create necessary resources in the
-`kube-service-catalog-controller-manager` namespace for deploying the Service Catalog API Server.
+`openshift-svcat-controller-manager-operator` namespace for deploying the Service Catalog API Server.
 
-Watch for service catalog controller manager to come up in the kube-service-catalog-controller-manager namespace.
+Watch for service catalog controller manager to come up in the `openshift-svcat-controller-manager-operator` namespace.
 
 ## Verification & debugging
 Nothing happens without the CR:

--- a/manifests/0000_90_svcat-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_svcat-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: svcat-controller-manager
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-svcat-controller-manager-operator
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -14,5 +14,5 @@ spec:
       serverName: controller-manager.kube-service-catalog-controller-manager.svc
   namespaceSelector:
     matchNames:
-    - kube-service-catalog-controller-manager
+    - openshift-svcat-controller-manager-operator
   selector: {}


### PR DESCRIPTION
fix errors:
```console
servicemonitor.monitoring.coreos.com/openshift-svcat-controller-manager-operator created
Error from server (NotFound): error when creating "cluster-svcat-controller-manager-operator/manifests/0000_90_svcat-controller-manager-operator_03_operand-servicemonitor.yaml": namespaces "kube-service-catalog-controller-manager" not found
```