### PR TITLE
image name was 'hypershift' - must be 'service-catalog'

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,7 +6,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-svcat-controller-manager-operator
-  - name: hypershift
+  - name: service-catalog
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift/origin-v4.0:service-catalog


### PR DESCRIPTION
found today that CVO is setting the image to hypershift and not service catalog.  It appears the issue is the 'name' attribute in image-references.