### PR TITLE
Operand default log level changed to 3, operator pull policy should be IfNotPresent

### DIFF
--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: operator
         image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-svcat-controller-manager-operator
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443
           name: metrics

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -187,7 +187,7 @@ func manageServiceCatalogControllerManagerDeployment_v311_00_to_latest(client ap
 		required.Spec.Template.Spec.Containers[0].Image = imagePullSpec
 	}
 
-	level := 2
+	level := 3
 	switch options.Spec.LogLevel {
 	case operatorapiv1.TraceAll:
 		level = 8
@@ -196,7 +196,7 @@ func manageServiceCatalogControllerManagerDeployment_v311_00_to_latest(client ap
 	case operatorapiv1.Debug:
 		level = 4
 	case operatorapiv1.Normal:
-		level = 2
+		level = 3
 	}
 	required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("-v=%d", level))
 


### PR DESCRIPTION
* default log level for Service Catalog Controller pods should be 3 (Normal) which matches what we had in 3.x
* operator pull policy changed to IfNotPresent
