### PR TITLE
Bug 1685332: set priorityClassName to system-cluster-critical

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ spec:
 EOF
 ```
 Once the cluster `ServiceCatalogControllerManager` is found to exist and have a `managementState` of `Managed` the operator will create necessary resources in the
-`kube-service-catalog-controller-manager` namespace for deploying the Service Catalog API Server.
+`openshift-service-catalog-controller-manager` namespace for deploying the Service Catalog API Server.
 
-Watch for service catalog controller manager to come up in the kube-service-catalog-controller-manager namespace.
+Watch for service catalog controller manager to come up in the openshift-service-catalog-controller-manager namespace.
 
 ## Verification & debugging
 Nothing happens without the CR:

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/cm.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: config
 data:
   config.yaml:

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/crb-catalog-controller.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/crb-catalog-controller.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-controller
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/crb-controller-namespace-viewer-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/crb-controller-namespace-viewer-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-controller
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/ds.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: controller-manager
   labels:
     app: svcat-controller-manager
@@ -31,10 +31,10 @@ spec:
         - --secure-port
         - "6443"
         - --leader-election-namespace
-        - kube-service-catalog-controller-manager
+        - openshift-service-catalog-controller-manager
         - --leader-elect-resource-lock
         - configmaps
-        - --cluster-id-configmap-namespace=kube-service-catalog-controller-manager
+        - --cluster-id-configmap-namespace=openshift-service-catalog-controller-manager
         - --broker-relist-interval
         - "5m"
         - --feature-gates
@@ -80,5 +80,6 @@ spec:
           secretName: serving-cert
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/ns.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/ns.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kube-service-catalog-controller-manager
+  name: openshift-service-catalog-controller-manager
   labels:
     openshift.io/run-level: "1"

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/role-cluster-info-configmap.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/role-cluster-info-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cluster-info-configmap
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 rules:
 - apiGroups:     [""]
   resources:     ["configmaps"]

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/role-configmap-accessor.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/role-configmap-accessor.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: configmap-accessor
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 rules:
 - apiGroups:
   - ""

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/rolebinding-cluster-info-configmap.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/rolebinding-cluster-info-configmap.yaml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cluster-info-configmap-binding
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: cluster-info-configmap
 subjects:
 - kind: ServiceAccount
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: service-catalog-controller

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/rolebinding-configmap-accessor.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/rolebinding-configmap-accessor.yaml
@@ -2,11 +2,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: configmap-accessor-binding
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 roleRef:
   kind: Role
   name: configmap-accessor
 subjects:
 - kind: ServiceAccount
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: service-catalog-controller

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/sa.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/sa.yaml
@@ -2,4 +2,4 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: service-catalog-controller
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/servicemonitor-role.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/servicemonitor-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 rules:
 - apiGroups:
   - ""

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/servicemonitor-rolebinding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/servicemonitor-rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/bindata/v3.11.0/openshift-svcat-controller-manager/svc.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: controller-manager
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: operator
         image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-svcat-controller-manager-operator
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443
           name: metrics
@@ -57,5 +57,6 @@ spec:
           name: openshift-svcat-controller-manager-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	kubeAPIServerNamespaceName = "openshift-kube-apiserver" // only used in sync_ServiceCatalogControllerManager_v311_00.go to copy the configmap
-	targetNamespaceName        = "kube-service-catalog-controller-manager"
+	targetNamespaceName        = "openshift-service-catalog-controller-manager"
 	workQueueKey               = "key"
 	workloadFailingCondition   = "WorkloadFailing"
 )

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -62,7 +62,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _v3110OpenshiftSvcatControllerManagerCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: config
 data:
   config.yaml:
@@ -186,7 +186,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-controller
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 `)
 
 func v3110OpenshiftSvcatControllerManagerCrbCatalogControllerYamlBytes() ([]byte, error) {
@@ -214,7 +214,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-controller
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 `)
 
 func v3110OpenshiftSvcatControllerManagerCrbControllerNamespaceViewerBindingYamlBytes() ([]byte, error) {
@@ -254,7 +254,7 @@ func v3110OpenshiftSvcatControllerManagerDefaultconfigYaml() (*asset, error) {
 var _v3110OpenshiftSvcatControllerManagerDsYaml = []byte(`apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: controller-manager
   labels:
     app: svcat-controller-manager
@@ -284,10 +284,10 @@ spec:
         - --secure-port
         - "6443"
         - --leader-election-namespace
-        - kube-service-catalog-controller-manager
+        - openshift-service-catalog-controller-manager
         - --leader-elect-resource-lock
         - configmaps
-        - --cluster-id-configmap-namespace=kube-service-catalog-controller-manager
+        - --cluster-id-configmap-namespace=openshift-service-catalog-controller-manager
         - --broker-relist-interval
         - "5m"
         - --feature-gates
@@ -333,6 +333,7 @@ spec:
           secretName: serving-cert
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists
 `)
@@ -355,7 +356,7 @@ func v3110OpenshiftSvcatControllerManagerDsYaml() (*asset, error) {
 var _v3110OpenshiftSvcatControllerManagerNsYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
-  name: kube-service-catalog-controller-manager
+  name: openshift-service-catalog-controller-manager
   labels:
     openshift.io/run-level: "1"`)
 
@@ -378,7 +379,7 @@ var _v3110OpenshiftSvcatControllerManagerRoleClusterInfoConfigmapYaml = []byte(`
 kind: Role
 metadata:
   name: cluster-info-configmap
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 rules:
 - apiGroups:     [""]
   resources:     ["configmaps"]
@@ -405,7 +406,7 @@ var _v3110OpenshiftSvcatControllerManagerRoleConfigmapAccessorYaml = []byte(`api
 kind: Role
 metadata:
   name: configmap-accessor
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 rules:
 - apiGroups:
   - ""
@@ -438,14 +439,14 @@ var _v3110OpenshiftSvcatControllerManagerRolebindingClusterInfoConfigmapYaml = [
 kind: RoleBinding
 metadata:
   name: cluster-info-configmap-binding
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: cluster-info-configmap
 subjects:
 - kind: ServiceAccount
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: service-catalog-controller
 `)
 
@@ -468,13 +469,13 @@ var _v3110OpenshiftSvcatControllerManagerRolebindingConfigmapAccessorYaml = []by
 kind: RoleBinding
 metadata:
   name: configmap-accessor-binding
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 roleRef:
   kind: Role
   name: configmap-accessor
 subjects:
 - kind: ServiceAccount
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: service-catalog-controller
 `)
 
@@ -497,7 +498,7 @@ var _v3110OpenshiftSvcatControllerManagerSaYaml = []byte(`kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: service-catalog-controller
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 `)
 
 func v3110OpenshiftSvcatControllerManagerSaYamlBytes() ([]byte, error) {
@@ -519,7 +520,7 @@ var _v3110OpenshiftSvcatControllerManagerServicemonitorRoleYaml = []byte(`apiVer
 kind: Role
 metadata:
   name: prometheus-k8s
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 rules:
 - apiGroups:
   - ""
@@ -552,7 +553,7 @@ var _v3110OpenshiftSvcatControllerManagerServicemonitorRolebindingYaml = []byte(
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -581,7 +582,7 @@ func v3110OpenshiftSvcatControllerManagerServicemonitorRolebindingYaml() (*asset
 var _v3110OpenshiftSvcatControllerManagerSvcYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
-  namespace: kube-service-catalog-controller-manager
+  namespace: openshift-service-catalog-controller-manager
   name: controller-manager
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685332

see: openshift/origin#22217

For both the operator and operand, set priorityClassName="system-cluster-critical"

This requires changing the namespace from kube-service-catalog-controller-manager to **openshift-service-catalog-controller-manager**.

system-cluster-critical: Error creating: pods "controller-manager-" is forbidden: pods with system-cluster-critical priorityClass is not permitted in kube-service-catalog-controller-manager namespace

Discussed and ok'd by Derek.