### PR TITLE
use consistent namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ NAME                        VERSION   AVAILABLE   PROGRESSING   FAILING   SINCE
 svcat-controller-manager              True        False         False     10m
 
 ```
-Review operator pod logs from the `openshift-svcat-controller-manager-operator` namespace to see details of the operator processing.
+Review operator pod logs from the `openshift-service-catalog-controller-manager-operator` namespace to see details of the operator processing.
 
 
 The operator deployment events will give you an overview of what it's done.  Ensure its not looping & review the events:
 ```
-$ oc describe deployment openshift-svcat-controller-manager-operator -n openshift-svcat-controller-manager-operator
+$ oc describe deployment openshift-service-catalog-controller-manager-operator -n openshift-service-catalog-controller-manager-operator
 ```
 
 

--- a/manifests/0000_90_cluster-svcat-controller-manager-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_cluster-svcat-controller-manager-operator_00_prometheusrole.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   # TODO this should be a clusterrole
   name: prometheus-k8s
-  namespace: openshift-svcat-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_cluster-svcat-controller-manager-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_cluster-svcat-controller-manager-operator_01_prometheusrolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: openshift-svcat-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-svcat-controller-manager-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-svcat-controller-manager-operator_02_servicemonitor.yaml
@@ -1,8 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: openshift-svcat-controller-manager-operator
-  namespace: openshift-svcat-controller-manager-operator
+  name: openshift-service-catalog-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -16,11 +16,11 @@ spec:
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: metrics.openshift-svcat-controller-manager-operator.svc
+      serverName: metrics.openshift-service-catalog-controller-manager-operator.svc
   jobLabel: component
   namespaceSelector:
     matchNames:
-    - openshift-svcat-controller-manager-operator
+    - openshift-service-catalog-controller-manager-operator
   selector:
     matchLabels:
-      app: openshift-svcat-controller-manager-operator
+      app: openshift-service-catalog-controller-manager-operator

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-svcat-controller-manager-operator
+  name: openshift-service-catalog-controller-manager-operator

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-svcat-controller-manager-operator
-  name: openshift-svcat-controller-manager-operator-config
+  namespace: openshift-service-catalog-controller-manager-operator
+  name: openshift-service-catalog-controller-manager-operator-config
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/04_metricservice.yaml
+++ b/manifests/04_metricservice.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: openshift-svcat-controller-manager-operator-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: openshift-service-catalog-controller-manager-operator-serving-cert
   labels:
-    app: openshift-svcat-controller-manager-operator
+    app: openshift-service-catalog-controller-manager-operator
   name: metrics
-  namespace: openshift-svcat-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
 spec:
   ports:
   - name: https
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: openshift-svcat-controller-manager-operator
+    app: openshift-service-catalog-controller-manager-operator
   sessionAffinity: None
   type: ClusterIP

--- a/manifests/06_roles.yaml
+++ b/manifests/06_roles.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:openshift:operator:openshift-svcat-controller-manager-operator
+  name: system:openshift:operator:openshift-service-catalog-controller-manager-operator
 roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  namespace: openshift-svcat-controller-manager-operator
-  name: openshift-svcat-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
+  name: openshift-service-catalog-controller-manager-operator

--- a/manifests/07_serviceaccount.yaml
+++ b/manifests/07_serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-svcat-controller-manager-operator
-  name: openshift-svcat-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
+  name: openshift-service-catalog-controller-manager-operator
   labels:
-    app: openshift-svcat-controller-manager-operator
+    app: openshift-service-catalog-controller-manager-operator

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: openshift-svcat-controller-manager-operator
-  name: openshift-svcat-controller-manager-operator
+  namespace: openshift-service-catalog-controller-manager-operator
+  name: openshift-service-catalog-controller-manager-operator
   labels:
-    app: openshift-svcat-controller-manager-operator
+    app: openshift-service-catalog-controller-manager-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openshift-svcat-controller-manager-operator
+      app: openshift-service-catalog-controller-manager-operator
   template:
     metadata:
-      name: openshift-svcat-controller-manager-operator
+      name: openshift-service-catalog-controller-manager-operator
       labels:
-        app: openshift-svcat-controller-manager-operator
+        app: openshift-service-catalog-controller-manager-operator
     spec:
-      serviceAccountName: openshift-svcat-controller-manager-operator
+      serviceAccountName: openshift-service-catalog-controller-manager-operator
       containers:
       - name: operator
         image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-svcat-controller-manager-operator
@@ -49,12 +49,12 @@ spec:
       - name: serving-cert
         secret:
           defaultMode: 400
-          secretName: openshift-svcat-controller-manager-operator-serving-cert
+          secretName: openshift-service-catalog-controller-manager-operator-serving-cert
           optional: true
       - name: config
         configMap:
           defaultMode: 440
-          name: openshift-svcat-controller-manager-operator-config
+          name: openshift-service-catalog-controller-manager-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	KubeAPIServerNamespace = "openshift-kube-apiserver"
-	OperatorNamespace      = "openshift-svcat-controller-manager-operator"
+	OperatorNamespace      = "openshift-service-catalog-controller-manager-operator"
 	TargetNamespace        = "openshift-service-catalog-controller-manager"
 )


### PR DESCRIPTION
See to https://github.com/openshift/cluster-svcat-apiserver-operator/pull/37 for additional background.

To make things consistent, this PR changes the operator namespace from "openshift-svcat-controller-manager-operator" to "openshift-service-catalog-controller-manager-operator" 
