### PR TITLE
Add node-selector annotation to namespace

### DIFF
--- a/bindata/v3.11.0/openshift-svcat-controller-manager/ns.yaml
+++ b/bindata/v3.11.0/openshift-svcat-controller-manager/ns.yaml
@@ -5,3 +5,5 @@ metadata:
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
+  annotations:
+    openshift.io/node-selector: ""

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -4,3 +4,5 @@ metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-service-catalog-controller-manager-operator
+  annotations:
+    openshift.io/node-selector: ""

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -391,6 +391,8 @@ metadata:
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
+  annotations:
+    openshift.io/node-selector: ""
 `)
 
 func v3110OpenshiftSvcatControllerManagerNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Why this change?
When openshift/cluster-kube-apiserver-operator#394 merges, all the pods running openshift cluster will have a defaultNodeSelector if it has been set by cluster-admin including pods running in openshift-* namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

What should I do?
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.

/cc @deads2k @ravisantoshgudimetla