### PR TITLE
Add the version option do display its commit info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 IMAGE ?= docker.io/openshift/origin-cluster-svcat-controller-manager-operator
 TAG ?= latest
 PROG  := cluster-svcat-controller-manager-operator
-GOFLAGS :=
+REPO_PATH:= github.com/openshift/cluster-svcat-controller-manager-operator
+GOFLAGS := -ldflags "-X '${REPO_PATH}/pkg/version.SourceGitCommit=$(shell git rev-parse HEAD)'"
 
 all: build build-image verify
 .PHONY: all
 build:
-	GODEBUG=tls13=1 go build $(GOFLAGS) ./cmd/cluster-svcat-controller-manager-operator
+	GODEBUG=tls13=1 go build ${GOFLAGS} ./cmd/cluster-svcat-controller-manager-operator
 .PHONY: build
 
 image:

--- a/cmd/cluster-svcat-controller-manager-operator/main.go
+++ b/cmd/cluster-svcat-controller-manager-operator/main.go
@@ -10,11 +10,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/openshift/cluster-svcat-controller-manager-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-svcat-controller-manager-operator/pkg/version"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-
-	"github.com/openshift/cluster-svcat-controller-manager-operator/pkg/cmd/operator"
 )
+
+var versionFlag = goflag.Bool("version", false, "displays source commit info.")
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -24,6 +26,13 @@ func main() {
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	goflag.Parse()
+	if *versionFlag {
+		fmt.Print(version.Commit())
+		// Exit immediately
+		os.Exit(0)
+	}
 
 	command := NewSSCSCommand()
 	if err := command.Execute(); err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"github.com/openshift/cluster-svcat-controller-manager-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -18,6 +19,8 @@ var (
 	minorFromGit string
 	// build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 	buildDate string
+	// SourceGitCommit indicates which git commit the binary was built from
+	SourceGitCommit string
 )
 
 // Get returns the overall codebase version. It's for detecting
@@ -30,6 +33,11 @@ func Get() version.Info {
 		GitVersion: versionFromGit,
 		BuildDate:  buildDate,
 	}
+}
+
+// Commit returns a pretty string concatenation of SourceGitCommit
+func Commit() string {
+	return fmt.Sprintf("cluster-svcat-controller-manager-operator source git commit: %s\n", SourceGitCommit)
 }
 
 func init() {


### PR DESCRIPTION
Add the `--version` flag to display the source commit info. It will be more clear for the users to know which version they're using.
```console
mac:cluster-svcat-controller-manager-operator jianzhang$ ./cluster-svcat-controller-manager-operator --help
Usage of ./cluster-svcat-controller-manager-operator:
  -add_dir_header
    	If true, adds the file directory to the header
  -alsologtostderr
    	log to standard error as well as files
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -log_file string
    	If non-empty, use this log file
  -log_file_max_size uint
    	Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
  -logtostderr
    	log to standard error instead of files (default true)
  -skip_headers
    	If true, avoid header prefixes in the log messages
  -skip_log_headers
    	If true, avoid headers when opening log files
  -stderrthreshold value
    	logs at or above this threshold go to stderr (default 2)
  -v value
    	number for the log level verbosity
  -version
    	displays source commit info.
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
```

```console
mac:cluster-svcat-controller-manager-operator jianzhang$ ./cluster-svcat-controller-manager-operator --version
cluster-svcat-controller-manager-operator source git commit: 1e6837a26a8659c7245d8e9f0a847bbd4411d956
```