### PR TITLE
Bug 1769601: Register with the legacyregistry for metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,21 +1,22 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog"
 )
 
 var (
-	buildInfo = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	buildInfo = k8smetrics.NewGaugeVec(
+		&k8smetrics.GaugeOpts{
 			Name: "openshift_cluster_svcat_apiserver_operator_build_info",
 			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift Service Catalog Operator was built.",
 		},
 		[]string{"major", "minor", "gitCommit", "gitVersion"},
 	)
 
-	controllerManagerEnabled = prometheus.NewGauge(
-		prometheus.GaugeOpts{
+	controllerManagerEnabled = k8smetrics.NewGauge(
+		&k8smetrics.GaugeOpts{
 			Name: "service_catalog_controller_manager_enabled",
 			Help: "Indicates whether Service Catalog controller manager is enabled",
 		})
@@ -23,8 +24,8 @@ var (
 
 func init() {
 	// do the MustRegister here
-	prometheus.MustRegister(buildInfo)
-	prometheus.MustRegister(controllerManagerEnabled)
+	legacyregistry.MustRegister(buildInfo)
+	legacyregistry.MustRegister(controllerManagerEnabled)
 }
 
 // We will never want to panic our operator because of metric saving.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,7 +9,7 @@ import (
 var (
 	buildInfo = k8smetrics.NewGaugeVec(
 		&k8smetrics.GaugeOpts{
-			Name: "openshift_cluster_svcat_apiserver_operator_build_info",
+			Name: "openshift_cluster_svcat_controller_manager_operator_build_info",
 			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift Service Catalog Operator was built.",
 		},
 		[]string{"major", "minor", "gitCommit", "gitVersion"},


### PR DESCRIPTION
With the k8s 1.16 bump, metrics were broken. Similar to what they did in the kube-apiserver
https://github.com/kubernetes/kubernetes/pull/81531/files
