### PR TITLE
add create-only annotation

### DIFF
--- a/manifests/0000_90_cluster-svcat-controller-manager-operator_01_remover_job.yaml
+++ b/manifests/0000_90_cluster-svcat-controller-manager-operator_01_remover_job.yaml
@@ -3,6 +3,8 @@ kind: Job
 metadata:
   name: openshift-service-catalog-controller-manager-remover
   namespace: openshift-service-catalog-removed
+  annotations:
+    release.openshift.io/create-only: "true"
 spec:
   template:
     spec:


### PR DESCRIPTION
To prevent CVO from attempting to update the Jobs during an upgrade, use create only annotation.