### PR TITLE
Bug 1875900: verify the e2e test removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cluster-svcat-controller-manager-operator
 The cluster-svcat-controller-manager-operator installs and maintains a singleton instance of the OpenShift Service Catalog on a cluster.  Service Catalog is actually comprised of an aggregated API server and a controller manager; this operator only deals with the Controller Manager portion of Service Catalog.  See the [cluster-svcat-apiserver-operator](https://github.com/openshift/cluster-svcat-apiserver-operator) for the operator responsible for the API Server component of Service Catalog.
 
-It should be noted this repo was initially copied from the OpenShift Controller Manager Operator (https://github.com/openshift/cluster-openshift-controller-manager-operator) and we generally try to keep it in sync with fixes and updates that are applicable.
+It should be noted this repo was initially copied from the [OpenShift Controller Manager Operator](https://github.com/openshift/cluster-openshift-controller-manager-operator) and we generally try to keep it in sync with fixes and updates that are applicable.
 
 [The Cluster Version Operator](https://github.com/openshift/cluster-version-operator) installs cluster operators by collecting the files within each cluster operator's manifest directory, bundling them into a release payload, and then `oc apply`ing them.  Note that unlike most cluster operators, this operator's configuration specifies that the initial management state of the Operator is `Removed`.  That is, the cluster operator is installed and running, but the operand is not.
 


### PR DESCRIPTION
As title, modify the README to verify if the e2e test removed from the master branch. Details: https://bugzilla.redhat.com/show_bug.cgi?id=1875900